### PR TITLE
Prevent animation tick from getting out of range.

### DIFF
--- a/method-draw/src/method-draw.js
+++ b/method-draw/src/method-draw.js
@@ -684,6 +684,8 @@
           var progress = Date.now() - start
           var tick = progress / duration
           tick = (Math.pow((tick-1), 3) +1);
+          if (tick > 1) tick = 1;
+          if (tick < -.90) tick = -.90;
           svgCanvas.setZoom(current_zoom + (diff*tick));
           updateCanvas();
           if (tick < 1 && tick > -.90) {


### PR DESCRIPTION
I run into a situation in which the second animation would occur seconds after the first frame. I think that this caused the tick to get out of range, turning

```
current_zoom + (diff*tick)
```

into a negative value, making the scene have negative width and height, which made it disappear, and then making the rulers jump into an infinite loop.

This pull requests ensures that the tick is within the valid range.
