### PR TITLE
fix issue where pointer-events are reset

### DIFF
--- a/editor/src/svgcanvas.js
+++ b/editor/src/svgcanvas.js
@@ -6635,7 +6635,10 @@ var leaveContext = this.leaveContext = function() {
       } else {
         elem.removeAttribute('opacity');
       }
-      elem.setAttribute('style', 'pointer-events: inherit');
+      //if pointer-events has been set to none, no overwrite will be made.
+      if(!/pointer-events\:\s?none/.test(elem.getAttribute("style"))){
+        elem.setAttribute('style', 'pointer-events: inherit');
+      }
     }
     disabled_elems = [];
     clearSelection(true);


### PR DESCRIPTION
Resetting the pointer-events will cause the pointer-events:none; of the parent node of the canvas_background element to be invalid. Clicking on the canvas_background node will cause the svgcanvas.js line:2285 getMouseTarget method to enter the last while, and the mouse_target returned will be #document. If there is an svg graphic on the canvas, it will cause the browser to die.