### PR TITLE
Introduce gulp watch script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,9 @@ const useref = require('gulp-useref');
 const replace = require('gulp-replace');
 const cachebust = require('gulp-cache-bust');
 const minify = require('gulp-minify');
+const browserSync = require("browser-sync");
+
+const server = browserSync.create();
 
 gulp.task('css', function () {
   return gulp.src('src/css/*.css')
@@ -79,3 +82,31 @@ gulp.task('build',
       'canvg'
   )
 );
+
+gulp.task('serve', function () {
+  server.init({
+    server: {
+      baseDir: './dist',
+    },
+  });
+});
+
+gulp.task('reload', function (done) {
+  server.reload();
+  done();
+});
+
+gulp.task('watch', function () {
+  gulp.watch('src/css/*.css', gulp.series('css', 'reload'));
+  gulp.watch(['src/js/*.js', 'src/lib/*.js'], gulp.series('js', 'reload'));
+  gulp.watch('src/js/loading.js', gulp.series('loading', 'reload'));
+  gulp.watch('src/*.html', gulp.series('index', 'reload'));
+  gulp.watch('src/site.webmanifest', gulp.series('manifest', 'reload'));
+  gulp.watch('src/images/**/*', gulp.series('images', 'reload'));
+  gulp.watch('src/font-files/**/*', gulp.series('fonts', 'reload'));
+  gulp.watch('src/extensions/**/*', gulp.series('extensions', 'reload'));
+  gulp.watch('src/shapelib/**/*', gulp.series('shapelib', 'reload'));
+  gulp.watch(['src/js/lib/canvg.js', 'src/js/lib/rgbcolor.js'], gulp.series('canvg', 'reload'));
+});
+
+gulp.task('dev', gulp.series('build', gulp.parallel('watch', 'serve')));

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "test": "test"
   },
   "scripts": {
+    "build": "gulp build",
+    "dev": "gulp dev",
     "test": "test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/methodofaction/Method-Draw#readme",
   "devDependencies": {
+    "browser-sync": "2.27.4",
     "gulp": "^4.0.2",
     "gulp-cache-bust": "^1.4.1",
     "gulp-concat": "^2.6.1",

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,12 @@ cd src
 python -m http.server 8000
 ```
 
+or using npm:
+
+```sh
+npm run dev
+```
+
 ## Build
 
 Install dev dependencies:
@@ -36,7 +42,7 @@ Install dev dependencies:
 
 Then you can build into `dist` by running:
 
-`gulp build`
+`npm run build`
 
 Deploy `dist` to your static file server of choice.
 


### PR DESCRIPTION
To help ease the development, gulp and npm scripts for serving and watching the source files for changes are introduced.
The built files, generated from `gulp build`, are served and watched for changes by browser-sync, since some features doesn't work when serving the `./src` folder directly
The watch task in gulp re-uses previous defined jobs, and uses gulp built-in watcher to watch for changes in the source files.
Updated README to describe the use of npm scripts, since the replaced README description required gulp to be installed globally to work
