### PR TITLE
Attribute xlink:href redefined

### DIFF
--- a/src/js/svgutils.js
+++ b/src/js/svgutils.js
@@ -322,7 +322,8 @@ svgedit.utilities.getHref = function(elem) {
 // Sets the given element's xlink:href value
 svgedit.utilities.setHref = function(elem, val) {
   elem.setAttributeNS(XLINKNS, "xlink:href", val);
-  //elem.setAttribute("href", val);
+  // Remove duplicated
+  // elem.setAttribute("href", val);
 }
 
 // Function: findDefs

--- a/src/js/svgutils.js
+++ b/src/js/svgutils.js
@@ -322,7 +322,7 @@ svgedit.utilities.getHref = function(elem) {
 // Sets the given element's xlink:href value
 svgedit.utilities.setHref = function(elem, val) {
   elem.setAttributeNS(XLINKNS, "xlink:href", val);
-  elem.setAttribute("href", val);
+  //elem.setAttribute("href", val);
 }
 
 // Function: findDefs


### PR DESCRIPTION
When a PNG image placed in the document, it throws an error "Attribute xlink:href redefined"