### PR TITLE
fix(UI): fix opacity bug

### DIFF
--- a/src/js/svgcanvas.js
+++ b/src/js/svgcanvas.js
@@ -50,7 +50,8 @@ var curConfig = {
   initStroke: {width: 1, color: '000', opacity: 1},
   imgPath: 'images/',
   baseUnit: 'px',
-  defaultFont: "Noto Sans JP"
+  defaultFont: "Noto Sans JP",
+  initOpacity: 1
 };
 
 // Update config with new one if given


### PR DESCRIPTION
## Issue
- `initOpacity` is missing from the `curConfig` object, which sets the `opacity: undefined` when building 'all_properties` on [Line 132](https://github.com/methodofaction/Method-Draw/blob/master/src/js/svgcanvas.js#L131)
- this results in the svg source containing `opacity="undefined"`.

## Changes
- added `initOpacity: 1` to the `curConfig` object.